### PR TITLE
Null Chek and Interescting grid check

### DIFF
--- a/HangarChecks/PlayerChecks.cs
+++ b/HangarChecks/PlayerChecks.cs
@@ -387,9 +387,6 @@ namespace QuantumHangar.HangarChecks
             if (!RequireLoadCurrency(Stamp))
                 return;
 
-            if (!CheckForIntersectingGrids(Stamp, Grids.ToList(), ID))
-                return;
-
             PluginDependencies.BackupGrid(Grids.ToList(), IdentityID);
             Vector3D SpawnPos = DetermineSpawnPosition(Stamp.GridSavePosition, PlayerPosition, out bool KeepOriginalPosition, LoadNearPlayer);
 
@@ -427,24 +424,6 @@ namespace QuantumHangar.HangarChecks
 
             if (BiggestGrid != null && IdentityID != 0)
                 CharacterUtilities.SendGps(BiggestGrid.PositionComp.GetPosition(), BiggestGrid.DisplayName, IdentityID);
-        }
-        private bool CheckForIntersectingGrids(GridStamp stamp, List<MyObjectBuilder_CubeGrid> grids, int ID)
-        {
-            if (Config.RequireLoadRadius) return true;
-            var pos = stamp.GridSavePosition;
-            var box = BoundingBoxD.CreateFromSphere(new BoundingSphere(pos, 200));
-
-            List<MyEntity> entsInBox = new List<MyEntity>();
-            MyGamePruningStructure.GetAllEntitiesInBox(ref box, entsInBox);
-            Log.Warn("Checkign bounding box.");
-            foreach (MyEntity e in entsInBox)
-            {
-                if (e == null) continue;
-                if (e is MyCharacter) continue;
-                Chat.Respond("Something is in the way.");
-                return false;
-            }
-            return true;
         }
 
         private bool CheckZoneRestrictions(bool IsSave)

--- a/HangarChecks/PlayerChecks.cs
+++ b/HangarChecks/PlayerChecks.cs
@@ -387,7 +387,8 @@ namespace QuantumHangar.HangarChecks
             if (!RequireLoadCurrency(Stamp))
                 return;
 
-
+            if (!CheckForIntersectingGrids(Stamp, Grids.ToList(), ID))
+                return;
 
             PluginDependencies.BackupGrid(Grids.ToList(), IdentityID);
             Vector3D SpawnPos = DetermineSpawnPosition(Stamp.GridSavePosition, PlayerPosition, out bool KeepOriginalPosition, LoadNearPlayer);
@@ -426,6 +427,24 @@ namespace QuantumHangar.HangarChecks
 
             if (BiggestGrid != null && IdentityID != 0)
                 CharacterUtilities.SendGps(BiggestGrid.PositionComp.GetPosition(), BiggestGrid.DisplayName, IdentityID);
+        }
+        private bool CheckForIntersectingGrids(GridStamp stamp, List<MyObjectBuilder_CubeGrid> grids, int ID)
+        {
+            if (Config.RequireLoadRadius) return true;
+            var pos = stamp.GridSavePosition;
+            var box = BoundingBoxD.CreateFromSphere(new BoundingSphere(pos, 200));
+
+            List<MyEntity> entsInBox = new List<MyEntity>();
+            MyGamePruningStructure.GetAllEntitiesInBox(ref box, entsInBox);
+            Log.Warn("Checkign bounding box.");
+            foreach (MyEntity e in entsInBox)
+            {
+                if (e == null) continue;
+                if (e is MyCharacter) continue;
+                Chat.Respond("Something is in the way.");
+                return false;
+            }
+            return true;
         }
 
         private bool CheckZoneRestrictions(bool IsSave)
@@ -566,6 +585,7 @@ namespace QuantumHangar.HangarChecks
                         continue;
 
                     long PlayerID = OnlinePlayer.GetPlayerIdentityId();
+                    if (PlayerID == 0L) continue;
                     if (PlayerID == IdentityID)
                         continue;
 

--- a/HangarChecks/PlayerHangar.cs
+++ b/HangarChecks/PlayerHangar.cs
@@ -131,9 +131,20 @@ namespace QuantumHangar.HangarChecks
             if (SelectedPlayerFile.Timer != null)
             {
                 TimeStamp Old = SelectedPlayerFile.Timer;
+                TimeSpan WaitTimeSpawn;
                 //There is a time limit!
                 TimeSpan Subtracted = DateTime.Now.Subtract(Old.OldTime);
-                TimeSpan WaitTimeSpawn = new TimeSpan(0, (int)Config.WaitTime, 0);
+                if (Config.WaitTime > 60)
+                {
+                    int hours = (int)Config.WaitTime / 60;
+                    int minutes = (int)Config.WaitTime - (hours* 60);
+                    WaitTimeSpawn = new TimeSpan(hours, minutes, 0);
+                }
+                else
+                {
+                    WaitTimeSpawn = new TimeSpan(0, (int)Config.WaitTime, 0);
+                }
+                
                 TimeSpan Remainder = WaitTimeSpawn - Subtracted;
                 //Log.Info("TimeSpan: " + Subtracted.TotalMinutes);
                 if (Subtracted.TotalMinutes <= Config.WaitTime)


### PR DESCRIPTION
Added Player Null ID check to allow for AF11
Added check For Intersecting grids within 200m to stop people loading grinds on grind and causing explosions
  [will not fire if checkRadius is enabled]