### PR TITLE
Utilities/Settings: add missing }, forgotten in 32f1b3d

### DIFF
--- a/Utilities/Settings.cs
+++ b/Utilities/Settings.cs
@@ -116,7 +116,7 @@ namespace QuantumHangar
         public bool AdvancedDebug { get => _AdvancedDebug; set => SetValue(ref _AdvancedDebug, value); }
 
         private bool _EnableSubGrids = false;
-        public bool EnableSubGrids { get => _EnableSubGrids; set => SetValue(ref _EnableSubGrids, value); 
+        public bool EnableSubGrids { get => _EnableSubGrids; set => SetValue(ref _EnableSubGrids, value); }
 
 
         private bool _RequireRestockFee = false;


### PR DESCRIPTION
Forgot `}` in https://github.com/Casimir255/QuantumHangar/commit/32f1b3d0fbc7e98b5af0d570dc187a1c609f9b1a