### PR TITLE
dig out voxels if necessary before grid load, optional

### DIFF
--- a/UI/UserControlInterface.xaml
+++ b/UI/UserControlInterface.xaml
@@ -140,6 +140,9 @@
 
                             <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row ="11" Text="TransferGrid on load (Cross-Server without Sync)"  Margin="3" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="This is useful if you are not using cross server sync plugins. Note there are exploits in doing this"/>
                             <CheckBox Grid.Row="11" Grid.Column="2" Grid.ColumnSpan="3" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding OnLoadTransfer}">(Will transfer Authorship/Ownership)</CheckBox>
+
+                            <TextBlock Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalAlignment="Center" Text="Dig voxels on load (e.g. for underground bases)" ToolTip="If the grid was built inside dug out voxels (e.g. underground bases), voxels may have re-generated and require digging it out to load"/>
+                            <CheckBox Grid.Row="12" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding DigVoxels}"></CheckBox>
                         </Grid>
                     </GroupBox>
 

--- a/Utilities/Settings.cs
+++ b/Utilities/Settings.cs
@@ -82,6 +82,8 @@ namespace QuantumHangar
         private bool _RequireLoadRadius = true;
         public bool RequireLoadRadius { get => _RequireLoadRadius; set => SetValue(ref _RequireLoadRadius, value); }
 
+        private bool _DigVoxels = false;
+        public bool DigVoxels { get => _DigVoxels; set => SetValue(ref _DigVoxels, value); }
 
         private bool _BlackListRadioButton = false;
         public bool SBlockLimits { get => _BlackListRadioButton; set => SetValue(ref _BlackListRadioButton, value); }


### PR DESCRIPTION
Adding a new optional feature to dig voxels around the grid if necessary before load.

Requires #49 (to compile) and #51 (to work correctly)