### PR TITLE
add manifest.xml + auto zip on release

### DIFF
--- a/QuantumHangar.csproj
+++ b/QuantumHangar.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -178,4 +178,10 @@
     <Folder Include="HangarMarket\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+      xcopy /y /d "$(ProjectDir)manifest.xml" "$(ProjectDir)$(OutDir)"
+      powershell Compress-Archive -Path "$(ProjectDir)$(OutDir)*" -DestinationPath "$(ProjectDir)$(OutDir)QuantumHangar.zip" -Force
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<PluginManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Quantum Hangar</Name>
+  <Guid>24fc7724-0740-4a54-8bb3-1191fd3c8db5</Guid>
+  <Repository>Quantum Hangar</Repository>
+  <Version>v3.1.53</Version>
+</PluginManifest>


### PR DESCRIPTION
Removed debug for release build so binary doesn't include local paths.
manifest.xml has current version published on Torch website: v3.1.53
To publish a new version on torchapi website, it's as simple as starting
a new release build and publish the zip it created.