### PR TITLE
WIP: Add More Functionality to the Auto Hanger Admin Command

### DIFF
--- a/AutoHangar/Autohangar.cs
+++ b/AutoHangar/Autohangar.cs
@@ -36,7 +36,7 @@ namespace QuantumHangar
                 RunAutoHangar();
         }
 
-        public static void RunAutoHangar()
+        public static void RunAutoHangar(bool hangerNow = false, bool hangerStatic = false, bool hangerLarge = false, bool hangerSmall = false, bool hangerLargest = false)
         {
             if (!Hangar.ServerRunning || !MySession.Static.Ready || MySandboxGame.IsPaused)
                 return;
@@ -45,14 +45,14 @@ namespace QuantumHangar
 
             try
             {
-                AutoHangarWorker();
+                AutoHangarWorker(hangerNow, hangerStatic, hangerLarge, hangerSmall, hangerLargest);
             }catch(Exception ex)
             {
                 Log.Error(ex);
             }
         }
 
-        private static void AutoHangarWorker()
+        private static void AutoHangarWorker(bool hangerNow = false, bool hangerStatic = false, bool hangerLarge = false, bool hangerSmall = false, bool hangerLargest = false)
         {
 
             //Significant performance increase
@@ -79,10 +79,10 @@ namespace QuantumHangar
                 if (SteamID == 0)
                     continue;
 
-                if (LastLogin.AddDays(Config.AutoHangarDayAmount) < DateTime.Now)
+                if (hangerNow || LastLogin.AddDays(Config.AutoHangarDayAmount) < DateTime.Now)
                 {
                     //AutoHangarBlacklist
-                    if (!Config.AutoHangarPlayerBlacklist.Any(x => x.SteamID == SteamID))
+                    if (hangerNow || !Config.AutoHangarPlayerBlacklist.Any(x => x.SteamID == SteamID))
                     {
                         ExportPlayerIdentities.Add(player.IdentityId);
                     }
@@ -107,7 +107,7 @@ namespace QuantumHangar
 
                 long LargestGridID = 0;
 
-                if (Config.KeepPlayersLargestGrid)
+                if (!hangerLargest && Config.KeepPlayersLargestGrid)
                 {
                     //First need to find their largets grid
                     int BlocksCount = 0;
@@ -169,7 +169,7 @@ namespace QuantumHangar
 
                     Result.BiggestGrid = BiggestGrid;
 
-                    if (Config.KeepPlayersLargestGrid)
+                    if (!hangerLargest && Config.KeepPlayersLargestGrid)
                     {
                         if (BiggestGrid.EntityId == LargestGridID)
                         {
@@ -182,16 +182,16 @@ namespace QuantumHangar
                     //Grid Size Checks
                     if (BiggestGrid.GridSizeEnum == MyCubeSize.Large)
                     {
-                        if (BiggestGrid.IsStatic && !Config.AutoHangarStaticGrids)
+                        if (!hangerStatic && BiggestGrid.IsStatic && !Config.AutoHangarStaticGrids)
                         {
                             continue;
                         }
-                        else if (!BiggestGrid.IsStatic && !Config.AutoHangarLargeGrids)
+                        else if (!hangerLarge && !BiggestGrid.IsStatic && !Config.AutoHangarLargeGrids)
                         {
                             continue;
                         }
                     }
-                    else if (BiggestGrid.GridSizeEnum == MyCubeSize.Small && !Config.AutoHangarSmallGrids)
+                    else if (!hangerSmall && BiggestGrid.GridSizeEnum == MyCubeSize.Small && !Config.AutoHangarSmallGrids)
                     {
                         continue;
                     }

--- a/Commands/HangarAdminCommands.cs
+++ b/Commands/HangarAdminCommands.cs
@@ -65,11 +65,43 @@ namespace QuantumHangar.Commands
             await HangarCommandSystem.RunAdminTaskAsync(() => User.SyncAll());
         }
 
-        [Command("autohangar", "Runs Autohangar ( [hangerNow (true/false)] [hangerStatic (true/false)] [hangerLarge (true/false)] [hangerSmall (true/false)] )")]
+        [Command("autohangar", "Runs Autohangar")]
         [Permission(MyPromoteLevel.Moderator)]
-        public async void RunAutoHangar(bool hangerNow = false, bool hangerStatic = false, bool hangerLarge = false, bool hangerSmall = false, bool hangerLargest = false)
+        public async void RunAutoHangar()
         {
-            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar(hangerNow, hangerStatic, hangerLarge, hangerSmall, hangerLargest));
+            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar());
+        }
+
+        [Command("autohanger-override", "Runs Autohanger with override values (staticgrids, largegrids, smallgrids, hangerLargest, saveAll)")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public async void RunAutoHangerOverride(String[] overrides)
+        {
+            bool staticgrids = false;
+            bool largegrids = false;
+            bool smallgrids = false;
+            bool hangerLargest = false;
+            bool saveAll = false;
+
+            foreach (var _override in overrides) {
+                if (_override == "staticgrids")
+                {
+                    staticgrids = true;
+                } else if (_override == "largegrids")
+                {
+                    largegrids = true;
+                } else if (_override == "smallgrids")
+                {
+                    smallgrids = true;
+                } else if (_override == "hangerLargest")
+                {
+                    hangerLargest = true;
+                } else if (_override == "saveAll")
+                {
+                    saveAll = true;
+                }
+            }
+            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar(saveAll, staticgrids, largegrids, smallgrids, hangerLargest));
+
         }
 
         [Command("enable", "Enables Hangar")]

--- a/Commands/HangarAdminCommands.cs
+++ b/Commands/HangarAdminCommands.cs
@@ -65,11 +65,11 @@ namespace QuantumHangar.Commands
             await HangarCommandSystem.RunAdminTaskAsync(() => User.SyncAll());
         }
 
-        [Command("autohangar", "Runs Autohangar")]
+        [Command("autohangar", "Runs Autohangar ( [hangerNow (true/false)] [hangerStatic (true/false)] [hangerLarge (true/false)] [hangerSmall (true/false)] )")]
         [Permission(MyPromoteLevel.Moderator)]
-        public async void RunAutoHangar()
+        public async void RunAutoHangar(bool hangerNow = false, bool hangerStatic = false, bool hangerLarge = false, bool hangerSmall = false, bool hangerLargest = false)
         {
-            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar());
+            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar(hangerNow, hangerStatic, hangerLarge, hangerSmall, hangerLargest));
         }
 
         [Command("enable", "Enables Hangar")]
@@ -136,11 +136,11 @@ namespace QuantumHangar.Commands
 
         }
 
-        [Command("autohangar", "Runs Autohangar")]
+        [Command("autohangar", "Runs Autohangar ( [hangerNow (true/false)] [hangerStatic (true/false)] [hangerLarge (true/false)] [hangerSmall (true/false)] )")]
         [Permission(MyPromoteLevel.Moderator)]
-        public async void RunAutoHangar()
+        public async void RunAutoHangar(bool hangerNow = false, bool hangerStatic = false, bool hangerLarge = false, bool hangerSmall = false, bool hangerLargest = false)
         {
-            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar());
+            await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar(hangerNow, hangerStatic, hangerLarge, hangerSmall, hangerLargest));
         }
 
         [Command("enable", "Enables Hangar")]


### PR DESCRIPTION
Example: /hm autohanger [hangerNow (true/false)] [hangerStatic (true/false)] [hangerLarge (true/false)] [hangerSmall (true/false)]

The goal of this PR is to allow Admins to Auto-Hanger all grids for special events such as a world reset / cluster rebuild.  This should hopefully reduce the overhead Admins face when doing a world cluster rebuild while in addition allowing them to safely preserve player grids and thus prevent upset players loosing their stuff if the world has to reset unexpectedly. 

I am leaving this as WIP for now so that the command changes can be refined as needed.  I have tested this and it works in a local torch instance.