### PR TITLE
Allow optional load from hangar when enemy present.

### DIFF
--- a/Quantumhangar/HangarChecks/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/PlayerChecks.cs
@@ -656,7 +656,7 @@ namespace QuantumHangar.HangarChecks
                         continue;
                     }
 
-                    if (Vector3D.Distance(Position, Pos) <= Config.DistanceCheck)
+                    if (Vector3D.Distance(Position, Pos) <= Config.DistanceCheck  && !Config.AllowLoadNearEnemy)
                     {
                         Chat?.Respond("Unable to load grid! Enemy within " + Config.DistanceCheck + "m!");
                         GpsSender.SendGps(Position, "Failed Hangar Load! (Enemy nearby)", IdentityID);
@@ -716,7 +716,7 @@ namespace QuantumHangar.HangarChecks
                     }
 
 
-                    if (!FoundAlly)
+                    if (!FoundAlly && !Config.AllowLoadNearEnemy)
                     {
                         //Stop loop
                         Chat?.Respond("Unable to load grid! Enemy within " + Config.GridDistanceCheck + "m!");

--- a/Quantumhangar/UI/UserControlInterface.xaml
+++ b/Quantumhangar/UI/UserControlInterface.xaml
@@ -112,6 +112,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <TextBlock Grid.Column="0" Grid.Row ="3" Text="Enable Plugin:" Margin="3" Grid.ColumnSpan="2"/>
@@ -140,15 +141,17 @@
                             <TextBlock Grid.Column="0" Grid.Row ="10" Margin="3" Grid.ColumnSpan="2" ToolTip="Only single grids in your hangar. (no connectors etc)">Allow saving of subgrids (Connectors and Gear): <LineBreak/> pistons/rotors are included by default!</TextBlock>
                             <CheckBox Grid.Row="10" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding EnableSubGrids}"/>
 
+                            <TextBlock Grid.Row="11" Grid.Column="0" Margin="3" Grid.ColumnSpan="2" ToolTip="Saving to hangar would still not be possible if disallowed in Extended settings.">Allow loading of grids when enemy nearby:</TextBlock>
+                            <CheckBox Grid.Row="11" Grid.Column="2" Grid.ColumnSpan="3" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding AllowLoadNearEnemy}">Saving to hangar would still not be allowed.</CheckBox>
 
-                            <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row ="11" Text="Transfer Grid on load (Cross-Server without Sync)"  Margin="3" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="This is useful if you are not using cross server sync plugins. Note there are exploits in doing this"/>
-                            <CheckBox Grid.Row="11" Grid.Column="2" Grid.ColumnSpan="3" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding OnLoadTransfer}">(Will transfer Authorship/Ownership)</CheckBox>
+                            <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row ="12" Text="Transfer Grid on load (Cross-Server without Sync)"  Margin="3" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="This is useful if you are not using cross server sync plugins. Note there are exploits in doing this"/>
+                            <CheckBox Grid.Row="12" Grid.Column="2" Grid.ColumnSpan="3" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding OnLoadTransfer}">(Will transfer Authorship/Ownership)</CheckBox>
 
-                            <TextBlock Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalAlignment="Center" Text="Dig voxels on load (grid bounding box)" ToolTip="If the grid was built inside dug out voxels (e.g. underground bases), voxels may have re-generated and require digging it out to load"/>
-                            <CheckBox Grid.Row="12" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding DigVoxels}"></CheckBox>
+                            <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalAlignment="Center" Text="Dig voxels on load (grid bounding box)" ToolTip="If the grid was built inside dug out voxels (e.g. underground bases), voxels may have re-generated and require digging it out to load"/>
+                            <CheckBox Grid.Row="13" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding DigVoxels}"></CheckBox>
 
-                            <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalAlignment="Center" Text="Nexus support (EXPERIMENTAL)" ToolTip="Relay load grid to the right server. Warning: does not yet work for all server types yet, only enable if you have a sectored setup + lobby"/>
-                            <CheckBox Grid.Row="13" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding NexusAPI}"></CheckBox>
+                            <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalAlignment="Center" Text="Nexus support (EXPERIMENTAL)" ToolTip="Relay load grid to the right server. Warning: does not yet work for all server types yet, only enable if you have a sectored setup + lobby"/>
+                            <CheckBox Grid.Row="14" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" IsChecked="{Binding NexusAPI}"></CheckBox>
                         </Grid>
                     </GroupBox>
 

--- a/Quantumhangar/Utilities/Settings.cs
+++ b/Quantumhangar/Utilities/Settings.cs
@@ -228,5 +228,8 @@ namespace QuantumHangar
         private bool _AutosellHangarGrids = false;
         public bool AutosellHangarGrids { get => _AutosellHangarGrids; set => SetValue(ref _AutosellHangarGrids, value); }
 
+
+        private bool _AllowLoadNearEnemy = false;
+        public bool AllowLoadNearEnemy { get => _AllowLoadNearEnemy; set => SetValue(ref _AllowLoadNearEnemy, value); }
     }
 }


### PR DESCRIPTION
Activate/deactive in torch plugin, the ability to load ships from hangar when enemy is present. Player cannot save grid to hangar when enabled. Anti-griefing feature.