### PR TITLE
Clean up and rework for new SE update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,5 @@ GameBinaries
 TorchBinaries
 NexusBinaries
 Setup (run before opening plugin).bat
+
+*.ini

--- a/HangarMarket/BeaconDetection.cs
+++ b/HangarMarket/BeaconDetection.cs
@@ -1,19 +1,13 @@
 ﻿using Sandbox.Common.ObjectBuilders;
 using Sandbox.ModAPI;
-using Sandbox.ModAPI.Interfaces;
 using SpaceEngineers.Game.ModAPI;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using VRage.Game.Components;
 using VRage.ObjectBuilders;
 using VRage.Game.ModAPI;
-using Sandbox.Definitions;
 using VRage.Game;
 using Sandbox.Game.EntityComponents;
-using VRage.Game.ObjectBuilders.Definitions;
-using Sandbox.ModAPI.Interfaces.Terminal;
 using VRage.ModAPI;
 
 namespace BeaconDetection

--- a/HangarMarket/HangarStoreMod.csproj
+++ b/HangarMarket/HangarStoreMod.csproj
@@ -1,134 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AC9B5B5D-5CBE-4535-ACBF-BB0D6F1E6204}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>HangarStoreMod</RootNamespace>
-    <AssemblyName>HangarStoreMod</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <TargetFramework>net48</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>6</LangVersion>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Include="App.config" />
+    <PackageReference Include="Mal.Mdk2.References" Version="2.2.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MarketSessionComponent.cs" />
-    <Compile Include="ModCore.cs" />
-    <Compile Include="ProtBufData.cs" />
-    <Compile Include="TerminalControls.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="ProtoBuf.Net.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\ProtoBuf.Net.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Sandbox.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\Sandbox.Common.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Sandbox.Game, Version=0.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\Sandbox.Game.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Sandbox.Graphics, Version=0.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\Sandbox.Graphics.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="SpaceEngineers.ObjectBuilders, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\SpaceEngineers.ObjectBuilders.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Game, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Game.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Input, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Input.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Library, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Library.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Math, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Math.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.NativeWrapper, Version=0.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.NativeWrapper.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Network, Version=1.0.53.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Network.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Render, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Render.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Render11, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Render11.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.Scripting, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Scripting.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="VRage.UserInterface, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\DedicatedServer64\VRage.UserInterface.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/HangarMarket/MarketSessionComponent.cs
+++ b/HangarMarket/MarketSessionComponent.cs
@@ -1,15 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Timers;
 using Sandbox.ModAPI;
-using VRage.Game;
-using VRage.Game.ModAPI;
-using VRage.Utils;
-using VRageMath;
-using System.Linq;
-using Sandbox.ModAPI.Interfaces.Terminal;
 using VRage.Game.Components;
 
 namespace HangarStoreMod

--- a/HangarMarket/ModCore.cs
+++ b/HangarMarket/ModCore.cs
@@ -3,13 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Sandbox.Common.ObjectBuilders;
-using Sandbox.Common.ObjectBuilders.Definitions;
 using Sandbox.Game.Entities;
-using Sandbox.Game.EntityComponents;
-using Sandbox.Game.Gui;
-using Sandbox.Game.World;
 using Sandbox.ModAPI;
 using Sandbox.ModAPI.Interfaces.Terminal;
 using VRage.Game;
@@ -19,7 +14,6 @@ using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using VRage.ObjectBuilders;
 using VRage.Utils;
-using VRageMath;
 
 
 namespace HangarStoreMod

--- a/HangarMarket/ProtBufData.cs
+++ b/HangarMarket/ProtBufData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using ProtoBuf;
 
 namespace HangarStoreMod

--- a/HangarMarket/TerminalControls.cs
+++ b/HangarMarket/TerminalControls.cs
@@ -125,17 +125,18 @@ namespace HangarStoreMod
         }
 
 
-        public static bool HideControls(IMyTerminalBlock block)
+        private static bool HideControls(IMyTerminalBlock block)
         {
-            if (!(block is IMyProjector projector)) return true;
+            var projector = block as IMyProjector;
+            if (projector == null) return true;
             return !projector.BlockDefinition.SubtypeName.Contains("HangarStoreBlock");
         }
 
 
-        public static bool ControlVisibility(IMyTerminalBlock block)
+        private static bool ControlVisibility(IMyTerminalBlock block)
         {
-            if (!(block is IMyProjector projector)) return false;
-            return projector.BlockDefinition.SubtypeName.Contains("HangarStoreBlock");
+            var projector = block as IMyProjector;
+            return projector != null && projector.BlockDefinition.SubtypeName.Contains("HangarStoreBlock");
         }
 
 

--- a/Quantumhangar/AutoHangar/Autohangar.cs
+++ b/Quantumhangar/AutoHangar/Autohangar.cs
@@ -8,12 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.Remoting.Contexts;
 using System.Threading.Tasks;
 using System.Timers;
 using VRage.Game;
-using VRage.Game.ModAPI;
-using VRage.Network;
 using VRageMath;
 
 namespace QuantumHangar

--- a/Quantumhangar/Commands/Alliances/AllianceHangerCommands.cs
+++ b/Quantumhangar/Commands/Alliances/AllianceHangerCommands.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using NLog.Targets;
-using QuantumHangar.HangarChecks;
+﻿using QuantumHangar.HangarChecks;
 using QuantumHangar.Utils;
 using Sandbox.Game.Entities;
 using Sandbox.Game.Entities.Character;
-using Sandbox.Game.Entities.Cube;
 using System.Collections.Generic;
-using Sandbox.Game.World;
 using Torch.Commands;
 using Torch.Commands.Permissions;
 using Torch.Mod;

--- a/Quantumhangar/Commands/Faction/FactionHangerCommands.cs
+++ b/Quantumhangar/Commands/Faction/FactionHangerCommands.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using NLog.Targets;
-using QuantumHangar.HangarChecks;
+﻿using QuantumHangar.HangarChecks;
 using QuantumHangar.Utils;
 using Sandbox.Game.Entities;
 using Sandbox.Game.Entities.Character;
-using Sandbox.Game.Entities.Cube;
 using System.Collections.Generic;
-using System.Linq;
-using Sandbox.Game.World;
 using Torch.Commands;
 using Torch.Commands.Permissions;
 using Torch.Mod;
 using Torch.Mod.Messages;
 using VRage.Game;
 using VRage.Game.ModAPI;
-using VRage.GameServices;
 using VRageMath;
 
 namespace QuantumHangar.Commands

--- a/Quantumhangar/Commands/HangarAdminCommands.cs
+++ b/Quantumhangar/Commands/HangarAdminCommands.cs
@@ -1,6 +1,5 @@
 ﻿using QuantumHangar.HangarChecks;
 using System;
-using System.Net.Mime;
 using Torch.Commands;
 using Torch.Commands.Permissions;
 using Torch.Mod;

--- a/Quantumhangar/Commands/Player/HangarCommands.cs
+++ b/Quantumhangar/Commands/Player/HangarCommands.cs
@@ -1,9 +1,7 @@
-﻿using NLog.Targets;
-using QuantumHangar.HangarChecks;
+﻿using QuantumHangar.HangarChecks;
 using QuantumHangar.Utils;
 using Sandbox.Game.Entities;
 using Sandbox.Game.Entities.Character;
-using Sandbox.Game.Entities.Cube;
 using System.Collections.Generic;
 using Torch.Commands;
 using Torch.Commands.Permissions;

--- a/Quantumhangar/Configs/SerializableData.cs
+++ b/Quantumhangar/Configs/SerializableData.cs
@@ -12,15 +12,11 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Windows.Controls;
 using Torch.Mod.Messages;
-using Torch.Mod;
 using VRage.Game;
-using VRage.Game.Factions.Definitions;
 using VRage.Game.ModAPI;
 using VRage.ObjectBuilders;
 using VRageMath;
-using static QuantumHangar.Utils.CharacterUtilities;
 
 namespace QuantumHangar
 {

--- a/Quantumhangar/Hangar.cs
+++ b/Quantumhangar/Hangar.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using Torch;
 using Torch.API;
@@ -14,7 +13,6 @@ using Torch.API.Managers;
 using Torch.API.Plugins;
 using Torch.API.Session;
 using Torch.Managers;
-using Torch.Managers.PatchManager;
 using Torch.Session;
 
 namespace QuantumHangar

--- a/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
+++ b/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NLog;
-using QuantumHangar.HangarMarket;
 using QuantumHangar.Serialization;
 using QuantumHangar.Utils;
 using Sandbox.Definitions;
@@ -16,7 +14,6 @@ using Sandbox.Game.World;
 using Torch.Mod;
 using Torch.Mod.Messages;
 using VRage.Game;
-using VRage.Game.ModAPI;
 
 namespace QuantumHangar.HangarChecks
 {

--- a/Quantumhangar/HangarChecks/Faction/FactionHanger.cs
+++ b/Quantumhangar/HangarChecks/Faction/FactionHanger.cs
@@ -15,7 +15,6 @@ using Sandbox.Game.World;
 using Torch.Mod;
 using Torch.Mod.Messages;
 using VRage.Game;
-using VRage.Game.ModAPI;
 
 namespace QuantumHangar.HangarChecks
 {

--- a/Quantumhangar/Properties/AssemblyInfo.cs
+++ b/Quantumhangar/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Quantumhangar/Properties/Debug.cs
+++ b/Quantumhangar/Properties/Debug.cs
@@ -1,9 +1,4 @@
 ﻿using Sandbox.ModAPI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VRage.Utils;
 
 namespace HangarStoreMod

--- a/Quantumhangar/QuantumHangar.csproj
+++ b/Quantumhangar/QuantumHangar.csproj
@@ -1,104 +1,48 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Project Properties -->
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{336836F1-76B8-43FB-ABEB-257E299E440D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>QuantumHangar</RootNamespace>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <AssemblyName>QuantumHangar</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <RootNamespace>QuantumHangar</RootNamespace>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
-    <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>latest</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
+    <UseWPF>true</UseWPF>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
   <PropertyGroup>
-    <StartupObject />
+    <PluginPackageName>QuantumHangar</PluginPackageName>
+    <PluginPackageDirectory>$(MSBuildProjectDirectory)\..\Build\</PluginPackageDirectory>
+    <PluginPackagePath>$(PluginPackageDirectory)$(PluginPackageName).zip</PluginPackagePath>
+    <PluginPackageStagingDirectory>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(TargetFramework)\$(PluginPackageName)\package\</PluginPackageStagingDirectory>
   </PropertyGroup>
-  <PropertyGroup>
-    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Include="App.config" />
+    <None Update="manifest.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
+
+  <!-- NuGet Package References -->
   <ItemGroup>
-    <Compile Include="AutoHangar\Autohangar.cs" />
-    <Compile Include="Commands\Alliances\AllianceHangerCommands.cs" />
-    <Compile Include="Commands\Faction\FactionHangerCommands.cs" />
-    <Compile Include="Commands\HangarCommandSystem.cs" />
-    <Compile Include="Commands\HangarAdminCommands.cs" />
-    <Compile Include="Commands\Player\HangarCommands.cs" />
-    <Compile Include="Hangar.cs" />
-    <Compile Include="HangarChecks\AdminChecks.cs" />
-    <Compile Include="HangarChecks\Alliances\AllianceChecks.cs" />
-    <Compile Include="HangarChecks\Alliances\AllianceHanger.cs" />
-    <Compile Include="HangarChecks\Faction\FactionHanger.cs" />
-    <Compile Include="HangarChecks\Faction\FactionChecks.cs" />
-    <Compile Include="HangarChecks\Player\PlayerChecks.cs" />
-    <Compile Include="HangarChecks\Player\PlayerHangar.cs" />
-    <Compile Include="Commands\HangarMarketCommands.cs" />
-    <Compile Include="HangarMarket\ClientCommunication.cs" />
-    <Compile Include="HangarMarket\HangarMarketController.cs" />
-    <Compile Include="HangarMarket\MarketListing.cs" />
-    <Compile Include="Properties\Debug.cs" />
-    <Compile Include="Serialization\GridSerializer.cs" />
-    <Compile Include="Utils\CommandCooldownChecker.cs" />
-    <Compile Include="Utils\FileLocker.cs" />
-    <Compile Include="Utils\GameEvents.cs" />
-    <Compile Include="Utils\ParallelSpawner.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Configs\SerializableData.cs" />
-    <Compile Include="Configs\Settings.cs" />
-    <Compile Include="UI\UserControlInterface.xaml.cs">
-      <DependentUpon>UserControlInterface.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Utils\CharacterUtilities.cs" />
-    <Compile Include="Utils\GridObjExtractor.cs" />
-    <Compile Include="Utils\GridUtilities.cs" />
-    <Compile Include="Utils\NexusAPI.cs" />
-    <Compile Include="Utils\PluginDependencies.cs" />
-    <Compile Include="Utils\NexusSupport.cs" />
-    <Compile Include="Utils\PreviewBoxTimer.cs" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
+
+  <!-- Torch and Space Engineers Assembly References -->
   <ItemGroup>
     <Reference Include="HavokWrapper">
       <HintPath>..\TorchBinaries\DedicatedServer64\HavokWrapper.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TorchBinaries\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="NLog">
       <HintPath>..\TorchBinaries\NLog.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
     <Reference Include="ProtoBuf.Net">
       <HintPath>..\TorchBinaries\DedicatedServer64\ProtoBuf.Net.dll</HintPath>
       <Private>False</Private>
@@ -131,7 +75,7 @@
       <HintPath>..\TorchBinaries\DedicatedServer64\SpaceEngineers.ObjectBuilders.XmlSerializers.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="Torch">
@@ -174,27 +118,28 @@
       <HintPath>..\TorchBinaries\DedicatedServer64\VRage.Mod.Io.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="WindowsBase" />
   </ItemGroup>
-  <ItemGroup>
-    <Page Include="UI\UserControlInterface.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="manifest.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-  <Target Name="Zip" BeforeTargets="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)\Build\" />
-    <ZipDirectory SourceDirectory="$(OutputPath)" DestinationFile="$(SolutionDir)\Build\$(MSBuildProjectName).zip" Overwrite="true" />
+
+  <Target Name="PackagePlugin" AfterTargets="Build">
+    <RemoveDir Directories="$(PluginPackageStagingDirectory)" />
+    <MakeDir Directories="$(PluginPackageStagingDirectory)" />
+    <MakeDir Directories="$(PluginPackageDirectory)" />
+
+    <ItemGroup>
+      <PluginPackageFiles Include="$(OutputPath)*"
+                          Exclude="$(OutputPath)*.pdb;$(OutputPath)$(PluginPackageName).zip" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(PluginPackageFiles)"
+      DestinationFiles="@(PluginPackageFiles->'$(PluginPackageStagingDirectory)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="false" />
+
+    <Delete Files="$(PluginPackagePath)" />
+    <ZipDirectory
+      SourceDirectory="$(PluginPackageStagingDirectory)"
+      DestinationFile="$(PluginPackagePath)"
+      Overwrite="true" />
   </Target>
+
 </Project>

--- a/Quantumhangar/Serialization/GridSerializer.cs
+++ b/Quantumhangar/Serialization/GridSerializer.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using VRage.Game;
 using VRage.ObjectBuilders;
 using VRage.ObjectBuilders.Private;

--- a/Quantumhangar/UI/UserControlInterface.xaml.cs
+++ b/Quantumhangar/UI/UserControlInterface.xaml.cs
@@ -1,31 +1,15 @@
-﻿using Newtonsoft.Json;
-using NLog;
+﻿using NLog;
 using QuantumHangar.HangarMarket;
-using QuantumHangar.Utilities;
 using QuantumHangar.Utils;
 using Sandbox.Game.World;
-using Sandbox.ModAPI;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.Windows.Threading;
-using VRage.Game;
-using VRage.ObjectBuilders;
 
 namespace QuantumHangar.UI
 {

--- a/Quantumhangar/Utils/CommandCooldownChecker.cs
+++ b/Quantumhangar/Utils/CommandCooldownChecker.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Sandbox.Game.World;
 using Torch.Commands;
 

--- a/Quantumhangar/Utils/FileLocker.cs
+++ b/Quantumhangar/Utils/FileLocker.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QuantumHangar.Utils
 {

--- a/Quantumhangar/Utils/GridObjExtractor.cs
+++ b/Quantumhangar/Utils/GridObjExtractor.cs
@@ -1,19 +1,4 @@
-﻿using Sandbox.Game;
-using Sandbox.Game.Entities;
-using Sandbox.Game.Entities.Cube;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using VRage.FileSystem;
-using VRage.Game.Models;
-using VRage.Utils;
-using VRageMath;
-using static System.Environment;
-
-namespace QuantumHangar.Utils
+﻿namespace QuantumHangar.Utils
 {
     public class GridObjExtractor
     {

--- a/Quantumhangar/Utils/NexusAPI.cs
+++ b/Quantumhangar/Utils/NexusAPI.cs
@@ -1,9 +1,6 @@
 ﻿using ProtoBuf;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VRage.Game;
 using VRageMath;
 

--- a/Quantumhangar/Utils/ParallelSpawner.cs
+++ b/Quantumhangar/Utils/ParallelSpawner.cs
@@ -1,35 +1,24 @@
 ﻿using NLog;
-using NLog.Targets.Wrappers;
-using ParallelTasks;
 using QuantumHangar.Utilities;
 using QuantumHangar.Utils;
 using Sandbox;
 using Sandbox.Common.ObjectBuilders;
 using Sandbox.Engine.Multiplayer;
-using Sandbox.Engine.Physics;
 using Sandbox.Game.Entities;
 using Sandbox.Game.GameSystems;
 using Sandbox.Game.Multiplayer;
-using Sandbox.Game.Screens.Helpers;
 using Sandbox.Game.World;
 using Sandbox.Game.World.Generator;
 using Sandbox.ModAPI;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
-using System.Windows.Controls;
-using System.Windows.Documents;
 using Torch.Commands;
-using Torch.Mod;
-using Torch.Mod.Messages;
 using VRage;
 using VRage.Game;
 using VRage.Game.Entity;
 using VRage.ModAPI;
-using VRage.Noise.Patterns;
-using VRage.Utils;
 using VRageMath;
 using static QuantumHangar.Utils.CharacterUtilities;
 
@@ -366,7 +355,7 @@ namespace QuantumHangar
             mObjectsInRange.Clear();
 
             MyProceduralWorldGenerator.Static.GetAllInSphere<MyStationCellGenerator>(inflated, mObjectsInRange);
-            mObstaclesInRange.AddRange(mObjectsInRange.Select(item4 => item4.UserData).OfType<MyStation>().Select(myStation => new BoundingBoxD(myStation.Position - MyStation.SAFEZONE_SIZE, myStation.Position + MyStation.SAFEZONE_SIZE)).Where(item => item.Contains(vector3D) != 0));
+            mObstaclesInRange.AddRange(mObjectsInRange.Select(item4 => item4.UserData).OfType<MyFactionStation>().Select(myStation => new BoundingBoxD(myStation.Position - MyFactionStation.SAFEZONE_SIZE, myStation.Position + MyFactionStation.SAFEZONE_SIZE)).Where(item => item.Contains(vector3D) != 0));
 
             mObjectsInRange.Clear();
 

--- a/Quantumhangar/Utils/PluginDependencies.cs
+++ b/Quantumhangar/Utils/PluginDependencies.cs
@@ -1,10 +1,7 @@
 ﻿using NLog;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Torch.API.Plugins;
 using Torch.Managers;
 using VRage.Game;

--- a/Quantumhangar/Utils/PreviewBoxTimer.cs
+++ b/Quantumhangar/Utils/PreviewBoxTimer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Documents;
 using Torch.Mod;
 using Torch.Mod.Messages;
 


### PR DESCRIPTION
This pull request primarily focuses on project file modernization, dependency management, and code cleanup for both the `HangarStoreMod` and `QuantumHangar` projects. The changes update the project files to use the modern .NET SDK style, streamline and centralize dependency management (especially via NuGet), and remove unused or redundant `using` directives throughout the codebase for better maintainability and clarity.

**Project and Dependency Management Updates:**

* Migrated `HangarStoreMod` and `QuantumHangar` project files (`.csproj`) to the SDK-style format, targeting .NET Framework 4.8, and updated build properties for modern development workflows. This includes switching to explicit NuGet package references (e.g., `Newtonsoft.Json`, `Mal.Mdk2.References`) and removing hardcoded assembly references in favor of package management. [[1]](diffhunk://#diff-f2e0d6b28fe490c2b9796db8ce075c2dfb3f493980f74ba0171d3b9aaba9cf41L1-L133) [[2]](diffhunk://#diff-e12fcc11d91d4fdfdfdfd99ddb8125e3881846ed6f4e5c07c8ed7686f9d3b78dL1-L101)
* Updated output paths, platform targets, and other build settings for consistency and compatibility with modern tooling. [[1]](diffhunk://#diff-f2e0d6b28fe490c2b9796db8ce075c2dfb3f493980f74ba0171d3b9aaba9cf41L1-L133) [[2]](diffhunk://#diff-e12fcc11d91d4fdfdfdfd99ddb8125e3881846ed6f4e5c07c8ed7686f9d3b78dL1-L101)

**Code Cleanup and Refactoring:**

* Removed unused or unnecessary `using` directives from multiple files across both projects, reducing clutter and potential confusion. This includes removal of unused system, game, and Torch namespaces. [[1]](diffhunk://#diff-bfcc5fe8da04ddbb562cc3369b2c144a885eaf5756f6a269fea67d44e4c0f8ffL3-L16) [[2]](diffhunk://#diff-7800128129bdfa8d2ae2f77b3b6bd6e8821fd806b69b2a5093b96f3b1f4234bcL3-L12) [[3]](diffhunk://#diff-26da6f2eeef0328009a6aed1f53e7f9a6282150f998abc4b8637bf5925be779dL6-L12) [[4]](diffhunk://#diff-26da6f2eeef0328009a6aed1f53e7f9a6282150f998abc4b8637bf5925be779dL22) [[5]](diffhunk://#diff-ae40fe97305e545b1dbb711b7a9fff0a4d96d00af2ff63f9364eb9b0a128f901L1-R1) [[6]](diffhunk://#diff-215b035992af34295e15f9684e1482853a849696092fc8b5403feef89eb48136L1-L9) [[7]](diffhunk://#diff-aeb27ceeaa4dd3e959ece9e20de4b83707c52bd6765a1e268d2a3cf2d6514ff3L1-L17) [[8]](diffhunk://#diff-97f2c468e768bb599240643807f810f5fe41373de295a0066bd896a0973c33d4L1-L6) [[9]](diffhunk://#diff-ee3f168aa2e2be26e35e9ca90ff24b9b2cade95e28703480afcbb775d77e0ddaL15-L23) [[10]](diffhunk://#diff-65c3767dd36ce19d282fe2c318d2bd9798c32d8872fd0ed7b2bcd2b01c5e85baL9-L17) [[11]](diffhunk://#diff-2debb5f2b73b3f7b292479acf508119e9a01f1b9e0343178a6d83900d18c41c9L6-L19) [[12]](diffhunk://#diff-ae0288d46811ff05375d854f59f931b7b72dde298e6a1484accec954aace4745L18) [[13]](diffhunk://#diff-82fc56ba3a5eb15f565f3f63d04ffa66ef90d1dca65a8e50d6294fd1a3365d21L2) [[14]](diffhunk://#diff-254e1642672de5218edda199a60ac05243e024bcc90e1df30463304defb65f46L2-L6)
* Changed some method access modifiers from `public` to `private` in `TerminalControls.cs` to encapsulate internal logic and reduce the public API surface.

These updates improve maintainability, make the build process more robust, and help ensure that only necessary dependencies and code are included in the projects.