### PR TITLE
Fix box drawing, add confirm action and projector restore

### DIFF
--- a/Quantumhangar/Commands/Player/HangarCommands.cs
+++ b/Quantumhangar/Commands/Player/HangarCommands.cs
@@ -31,6 +31,20 @@ namespace QuantumHangar.Commands
             await HangarCommandSystem.RunTaskAsync(() => user.SaveGrid(), Context);
         }
 
+        [Command("confirm", "Confirms staged save for highlighted grid")]
+        [Permission(MyPromoteLevel.None)]
+        public async void ConfirmSaveGrid()
+        {
+            if (Context.Player == null)
+            {
+                Context.Respond("This is a player only command!");
+                return;
+            }
+
+            var user = new PlayerChecks(Context);
+            await HangarCommandSystem.RunTaskAsync(() => user.ConfirmSaveGrid(), Context);
+        }
+
         [Command("list", "Lists all the grids saved in your hangar")]
         [Permission(MyPromoteLevel.None)]
         public async void ListGrids()
@@ -105,6 +119,20 @@ namespace QuantumHangar.Commands
 
             var user = new PlayerChecks(Context);
             await HangarCommandSystem.RunTaskAsync(() => user.SaveGrid(), Context);
+        }
+
+        [Command("confirm", "Confirms staged save for highlighted grid")]
+        [Permission(MyPromoteLevel.None)]
+        public async void ConfirmSaveGrid()
+        {
+            if (Context.Player == null)
+            {
+                Context.Respond("This is a player only command!");
+                return;
+            }
+
+            var user = new PlayerChecks(Context);
+            await HangarCommandSystem.RunTaskAsync(() => user.ConfirmSaveGrid(), Context);
         }
 
         [Command("list", "Lists all the grids saved in your hangar")]

--- a/Quantumhangar/Hangar.cs
+++ b/Quantumhangar/Hangar.cs
@@ -28,6 +28,9 @@ namespace QuantumHangar
         public static Dictionary<long, CurrentCooldown> ConfirmationsMap { get; } =
             new Dictionary<long, CurrentCooldown>();
 
+        public static Dictionary<long, PendingSaveConfirmation> PendingSaveConfirmations { get; } =
+            new Dictionary<long, PendingSaveConfirmation>();
+
         public TorchSessionManager TorchSession { get; private set; }
         public static bool ServerRunning { get; private set; }
 
@@ -39,6 +42,29 @@ namespace QuantumHangar
         public static MethodInfo HasAccess;
 
         public static ITorchPlugin Alliances;
+
+        public static bool TryGetPendingSaveConfirmation(long identityId, out PendingSaveConfirmation pendingSaveConfirmation)
+        {
+            if (!PendingSaveConfirmations.TryGetValue(identityId, out pendingSaveConfirmation))
+                return false;
+
+            if (!pendingSaveConfirmation.IsExpired())
+                return true;
+
+            PendingSaveConfirmations.Remove(identityId);
+            pendingSaveConfirmation = null;
+            return false;
+        }
+
+        public static void SetPendingSaveConfirmation(long identityId, PendingSaveConfirmation pendingSaveConfirmation)
+        {
+            PendingSaveConfirmations[identityId] = pendingSaveConfirmation;
+        }
+
+        public static void ClearPendingSaveConfirmation(long identityId)
+        {
+            PendingSaveConfirmations.Remove(identityId);
+        }
 
         public enum ErrorType
         {
@@ -231,6 +257,29 @@ namespace QuantumHangar
             var elapsedTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - _startTime;
 
             return elapsedTime >= 30000;
+        }
+    }
+
+    public class PendingSaveConfirmation
+    {
+        public const int TimeoutSeconds = 30;
+        private const long TimeoutMilliseconds = TimeoutSeconds * 1000;
+        private readonly long _createdAt;
+
+        public long BiggestGridEntityId { get; }
+        public string GridName { get; }
+
+        public PendingSaveConfirmation(long biggestGridEntityId, string gridName)
+        {
+            BiggestGridEntityId = biggestGridEntityId;
+            GridName = gridName;
+            _createdAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+
+        public bool IsExpired()
+        {
+            var elapsedTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - _createdAt;
+            return elapsedTime >= TimeoutMilliseconds;
         }
     }
 }

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -99,7 +99,7 @@ namespace QuantumHangar.HangarChecks
 
         }
 
-        public async void SaveGrid()
+        public void SaveGrid()
         {
             if (!PerformMainChecks(true))
                 return;
@@ -122,7 +122,7 @@ namespace QuantumHangar.HangarChecks
 
             //Calculates incoming grids data
             var gridData = result.GenerateGridStamp();
-         
+
 
             //PlayersHanger.CheckGridLimits(GridData);
 
@@ -135,15 +135,52 @@ namespace QuantumHangar.HangarChecks
                 return;
 
 
-            if (!RequireSaveCurrency(result))
+            if (!TryGetSaveCost(result, out var saveCost))
                 return;
 
 
+            StageSaveConfirmation(result, saveCost);
+        }
+
+        public void ConfirmSaveGrid()
+        {
+            if (!Hangar.TryGetPendingSaveConfirmation(_identityId, out var pendingSaveConfirmation))
+            {
+                PreviewBoxTimer.removeAll(SteamId);
+                _chat?.Respond("No staged grid found. Run !hangar save first.");
+                return;
+            }
+
+            Hangar.ClearPendingSaveConfirmation(_identityId);
+            PreviewBoxTimer.removeAll(SteamId);
+
+            if (!PerformMainChecks(true))
+                return;
+
+            if (!PlayersHanger.CheckHangarLimits())
+                return;
+
+            var result = new GridResult();
+            if (!result.GetGrids(_chat, _userCharacter, pendingSaveConfirmation.BiggestGridEntityId.ToString()))
+                return;
+
+            if (IsAnyGridInsideSafeZone(result))
+                return;
+
+            var gridData = result.GenerateGridStamp();
+            if (!PlayersHanger.ExtensiveLimitChecker(gridData))
+                return;
+
+            if (!CheckEnemyDistance(Config.LoadType, _playerPosition))
+                return;
+
+            if (!TryGetSaveCost(result, out var saveCost))
+                return;
+
+            ChargeSaveCurrency(saveCost);
             PlayersHanger.SelectedPlayerFile.FormatGridName(gridData);
 
-       
-
-            var val = await PlayersHanger.SaveGridsToFile(result, gridData.GridName);
+            var val = PlayersHanger.SaveGridsToFile(result, gridData.GridName).GetAwaiter().GetResult();
             if (val)
             {
                 PlayersHanger.SaveGridStamp(gridData);
@@ -155,16 +192,26 @@ namespace QuantumHangar.HangarChecks
             }
         }
 
-        private bool RequireSaveCurrency(GridResult result)
+        private void StageSaveConfirmation(GridResult result, long saveCost)
         {
-            //MyObjectBuilder_Definitions(MyParticlesManager)
+            PreviewBoxTimer.DisplayGridSelection(SteamId, result.Grids, PendingSaveConfirmation.TimeoutSeconds);
+            Hangar.SetPendingSaveConfirmation(_identityId,
+                new PendingSaveConfirmation(result.BiggestGrid.EntityId, result.GridName));
+
+            var costMessage = Config.RequireCurrency && saveCost > 0 ? " Cost: " + saveCost + " SC." : "";
+            _chat?.Respond("Grid staged: " + result.GridName + ". Run !hangar confirm within " +
+                          PendingSaveConfirmation.TimeoutSeconds + " secs to save highlighted grid." + costMessage);
+        }
+
+        private bool TryGetSaveCost(GridResult result, out long saveCost)
+        {
+            saveCost = 0;
             if (!Config.RequireCurrency)
             {
                 return true;
             }
             else
             {
-                long saveCost = 0;
                 switch (Config.HangarSaveCostType)
                 {
                     case CostType.BlockCount:
@@ -173,19 +220,15 @@ namespace QuantumHangar.HangarChecks
                             if (grid.GridSizeEnum == MyCubeSize.Large)
                             {
                                 if (grid.IsStatic)
-                                    //If grid is station
                                     saveCost += Convert.ToInt64(grid.BlocksCount * Config.CustomStaticGridCurrency);
                                 else
-                                    //If grid is large grid
                                     saveCost += Convert.ToInt64(grid.BlocksCount * Config.CustomLargeGridCurrency);
                             }
                             else
                             {
-                                //if its a small grid
                                 saveCost += Convert.ToInt64(grid.BlocksCount * Config.CustomSmallGridCurrency);
                             }
 
-                        //Multiply by 
                         break;
 
 
@@ -202,15 +245,12 @@ namespace QuantumHangar.HangarChecks
                             if (grid.GridSizeEnum == MyCubeSize.Large)
                             {
                                 if (grid.IsStatic)
-                                    //If grid is station
                                     saveCost += Convert.ToInt64(Config.CustomStaticGridCurrency);
                                 else
-                                    //If grid is large grid
                                     saveCost += Convert.ToInt64(Config.CustomLargeGridCurrency);
                             }
                             else
                             {
-                                //if its a small grid
                                 saveCost += Convert.ToInt64(Config.CustomSmallGridCurrency);
                             }
 
@@ -218,43 +258,21 @@ namespace QuantumHangar.HangarChecks
                 }
 
                 TryGetPlayerBalance(out var balance);
-
-
                 if (balance >= saveCost)
-                {
-                    //Check command status!
-                    var command = result.BiggestGrid.DisplayName;
-                    var confirmationCooldownMap = Hangar.ConfirmationsMap;
-                    if (confirmationCooldownMap.TryGetValue(_identityId, out var confirmationCooldown))
-                    {
-                        if (!confirmationCooldown.CheckCommandStatus(command))
-                        {
-                            //Confirmed command! Update player balance!
-                            confirmationCooldownMap.Remove(_identityId);
-                            _chat?.Respond("Confirmed! Saving grid!");
+                    return true;
 
-                            ChangeBalance(-1 * saveCost);
-                            return true;
-                        }
-                        _chat?.Respond("Saving this grid in your hangar will cost " + saveCost +
-                                      " SC. Run this command again within 30 secs to continue!");
-                        confirmationCooldown.StartCooldown(command);
-                        return false;
-                    }
-                    _chat?.Respond("Saving this grid in your hangar will cost " + saveCost +
-                                  " SC. Run this command again within 30 secs to continue!");
-                    confirmationCooldown = new CurrentCooldown();
-                    confirmationCooldown.StartCooldown(command);
-                    confirmationCooldownMap.Add(_identityId, confirmationCooldown);
-                    return false;
-                }
-                else
-                {
-                    var required = saveCost - balance;
-                    _chat?.Respond("You need an additional " + required + " SC to perform this action!");
-                    return false;
-                }
+                var required = saveCost - balance;
+                _chat?.Respond("You need an additional " + required + " SC to perform this action!");
+                return false;
             }
+        }
+
+        private void ChargeSaveCurrency(long saveCost)
+        {
+            if (!Config.RequireCurrency || saveCost <= 0)
+                return;
+
+            ChangeBalance(-1 * saveCost);
         }
 
         private bool RequireLoadCurrency(GridStamp grid)

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -151,9 +151,6 @@ namespace QuantumHangar.HangarChecks
                 return;
             }
 
-            Hangar.ClearPendingSaveConfirmation(_identityId);
-            PreviewBoxTimer.removeAll(SteamId);
-
             if (!PerformMainChecks(true))
                 return;
 
@@ -176,6 +173,9 @@ namespace QuantumHangar.HangarChecks
 
             if (!TryGetSaveCost(result, out var saveCost))
                 return;
+
+            Hangar.ClearPendingSaveConfirmation(_identityId);
+            PreviewBoxTimer.removeAll(SteamId);
 
             ChargeSaveCurrency(saveCost);
             PlayersHanger.SelectedPlayerFile.FormatGridName(gridData);

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -139,7 +139,7 @@ namespace QuantumHangar.HangarChecks
                 return;
 
 
-            StageSaveConfirmation(result, saveCost);
+            StageSaveConfirmation(result, gridData, saveCost);
         }
 
         public void ConfirmSaveGrid()
@@ -192,9 +192,9 @@ namespace QuantumHangar.HangarChecks
             }
         }
 
-        private void StageSaveConfirmation(GridResult result, long saveCost)
+        private void StageSaveConfirmation(GridResult result, GridStamp gridData, long saveCost)
         {
-            PreviewBoxTimer.DisplayGridSelection(SteamId, result.Grids, PendingSaveConfirmation.TimeoutSeconds);
+            PreviewBoxTimer.DisplayGridSelection(SteamId, gridData, PendingSaveConfirmation.TimeoutSeconds);
             Hangar.SetPendingSaveConfirmation(_identityId,
                 new PendingSaveConfirmation(result.BiggestGrid.EntityId, result.GridName));
 

--- a/Quantumhangar/Utils/ParallelSpawner.cs
+++ b/Quantumhangar/Utils/ParallelSpawner.cs
@@ -5,6 +5,7 @@ using Sandbox;
 using Sandbox.Common.ObjectBuilders;
 using Sandbox.Engine.Multiplayer;
 using Sandbox.Game.Entities;
+using Sandbox.Game.Entities.Blocks;
 using Sandbox.Game.GameSystems;
 using Sandbox.Game.Multiplayer;
 using Sandbox.Game.World;
@@ -13,6 +14,7 @@ using Sandbox.ModAPI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Torch.Commands;
 using VRage;
@@ -26,7 +28,24 @@ namespace QuantumHangar
 {
     public class ParallelSpawner
     {
+        private class SavedProjectorProjection
+        {
+            public MyObjectBuilder_CubeGrid GridBuilder { get; }
+            public Vector3I BlockPosition { get; }
+            public List<MyObjectBuilder_CubeGrid> ProjectedGrids { get; }
+
+            public SavedProjectorProjection(MyObjectBuilder_CubeGrid gridBuilder, Vector3I blockPosition,
+                List<MyObjectBuilder_CubeGrid> projectedGrids)
+            {
+                GridBuilder = gridBuilder;
+                BlockPosition = blockPosition;
+                ProjectedGrids = projectedGrids;
+            }
+        }
+
         private static List<commandTimer> recentCommands = new List<commandTimer>();
+        private static readonly MethodInfo SendNewProjection =
+            typeof(MyProjectorBase).GetMethod("SendNewBlueprint", BindingFlags.NonPublic | BindingFlags.Instance);
 
         private class commandTimer
         {
@@ -50,6 +69,7 @@ namespace QuantumHangar
 
         private readonly IEnumerable<MyObjectBuilder_CubeGrid> _grids;
         private readonly Action<HashSet<MyCubeGrid>> _callback;
+        private readonly List<SavedProjectorProjection> _savedProjectorProjections = new List<SavedProjectorProjection>();
 
         private readonly HashSet<MyCubeGrid> _spawned;
         private readonly Chat _response;
@@ -112,8 +132,14 @@ namespace QuantumHangar
 
                 foreach (var block in cubeGrid.CubeBlocks.OfType<MyObjectBuilder_Projector>())
                 {
+                    var projectedGrids = GetProjectedGrids(block);
+                    if (projectedGrids.Count > 0)
+                    {
+                        _savedProjectorProjections.Add(new SavedProjectorProjection(cubeGrid, block.Min, projectedGrids));
+                    }
+
                     block.ProjectedGrid = null;
-                    block.ProjectedGrids?.Clear();
+                    block.ProjectedGrids = null;
                 }
             }
 
@@ -565,7 +591,39 @@ namespace QuantumHangar
             foreach (var g in _spawned)
                 MyAPIGateway.Entities.AddEntity(g, true);
 
+            RestoreProjectorProjections();
             _callback?.Invoke(_spawned);
+        }
+
+        private static List<MyObjectBuilder_CubeGrid> GetProjectedGrids(MyObjectBuilder_Projector projector)
+        {
+            if (projector.ProjectedGrids != null && projector.ProjectedGrids.Count > 0)
+                return new List<MyObjectBuilder_CubeGrid>(projector.ProjectedGrids);
+
+            if (projector.ProjectedGrid != null)
+                return new List<MyObjectBuilder_CubeGrid> { projector.ProjectedGrid };
+
+            return new List<MyObjectBuilder_CubeGrid>();
+        }
+
+        private void RestoreProjectorProjections()
+        {
+            if (_savedProjectorProjections.Count == 0 || SendNewProjection == null)
+                return;
+
+            foreach (var projectorProjection in _savedProjectorProjections)
+            {
+                var grid = _spawned.FirstOrDefault(x => x.EntityId == projectorProjection.GridBuilder.EntityId);
+                if (grid == null)
+                    continue;
+
+                var projector =
+                    grid.GetCubeBlock(projectorProjection.BlockPosition)?.FatBlock as MyProjectorBase;
+                if (projector == null)
+                    continue;
+
+                SendNewProjection.Invoke(projector, new object[] { projectorProjection.ProjectedGrids });
+            }
         }
 
 

--- a/Quantumhangar/Utils/ParallelSpawner.cs
+++ b/Quantumhangar/Utils/ParallelSpawner.cs
@@ -611,19 +611,40 @@ namespace QuantumHangar
             if (_savedProjectorProjections.Count == 0 || SendNewProjection == null)
                 return;
 
+            var parameters = SendNewProjection.GetParameters();
+            if (parameters.Length != 1)
+                return;
+
             foreach (var projectorProjection in _savedProjectorProjections)
             {
                 var grid = _spawned.FirstOrDefault(x => x.EntityId == projectorProjection.GridBuilder.EntityId);
                 if (grid == null)
                     continue;
 
-                var projector =
-                    grid.GetCubeBlock(projectorProjection.BlockPosition)?.FatBlock as MyProjectorBase;
+                var projector = grid.GetCubeBlock(projectorProjection.BlockPosition)?.FatBlock as MyProjectorBase;
                 if (projector == null)
                     continue;
 
-                SendNewProjection.Invoke(projector, new object[] { projectorProjection.ProjectedGrids });
+                try
+                {
+                    object arg;
+                    var paramType = parameters[0].ParameterType;
+                    if (paramType.IsArray && paramType.GetElementType() == typeof(MyObjectBuilder_CubeGrid))
+                        arg = projectorProjection.ProjectedGrids.ToArray();
+                    else
+                        arg = projectorProjection.ProjectedGrids;
+
+                    SendNewProjection.Invoke(projector, new[] { arg });
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex,
+                        "Failed to restore projector blueprint for grid {0} at {1}",
+                        grid.EntityId,
+                        projectorProjection.BlockPosition);
+                }
             }
+        }
         }
 
 

--- a/Quantumhangar/Utils/PreviewBoxTimer.cs
+++ b/Quantumhangar/Utils/PreviewBoxTimer.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using Sandbox.Game.Entities;
+using System.Collections.Generic;
 using System.Linq;
 using Torch.Mod;
 using Torch.Mod.Messages;
+using VRage.Game;
+using VRageMath;
 
 namespace QuantumHangar.Utils
 {
@@ -12,15 +15,17 @@ namespace QuantumHangar.Utils
 
 
         public int timeDisplayed = 0;
-        private static int displayfor = 60; //display interferred boxes for 60 seconds
+        private const int DefaultDisplayFor = 60; //display interferred boxes for 60 seconds
+        private readonly int _displayFor;
 
         public DrawDebug drawobjectMessage;
         private ulong _target;
 
-        public PreviewBoxTimer(ulong target)
+        public PreviewBoxTimer(ulong target, int displayFor = DefaultDisplayFor)
         {
             drawobjectMessage = new DrawDebug(target.ToString());
             _target = target;
+            _displayFor = displayFor;
         }
 
         public void display()
@@ -46,7 +51,7 @@ namespace QuantumHangar.Utils
         {
             for (int i = list.Count - 1; i >= 0; i--)
             {
-                if (list[i].timeDisplayed > displayfor)
+                if (list[i].timeDisplayed > list[i]._displayFor)
                 {
                     list[i].remove();
                     list.RemoveAt(i);
@@ -70,6 +75,20 @@ namespace QuantumHangar.Utils
             }
         }
 
+        public static void DisplayGridSelection(ulong target, IEnumerable<MyCubeGrid> grids,
+            int displayFor = DefaultDisplayFor)
+        {
+            removeAll(target);
+
+            var timer = new PreviewBoxTimer(target, displayFor);
+            var color = new Color(255, 255, 0, 10);
+            foreach (var grid in grids)
+                timer.drawobjectMessage.addOBBLinkedEntity(grid.EntityId, color, MySimpleObjectRasterizer.Wireframe,
+                    1f, 0.005f);
+
+            timer.display();
+        }
+
         private void remove()
         {
             drawobjectMessage.remove = true;
@@ -82,6 +101,11 @@ namespace QuantumHangar.Utils
                 return timer._target == _target;
 
             return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _target.GetHashCode();
         }
     }
 }

--- a/Quantumhangar/Utils/PreviewBoxTimer.cs
+++ b/Quantumhangar/Utils/PreviewBoxTimer.cs
@@ -1,4 +1,5 @@
-﻿using Sandbox.Game.Entities;
+﻿using QuantumHangar;
+using Sandbox.Game.Entities;
 using System.Collections.Generic;
 using System.Linq;
 using Torch.Mod;
@@ -75,16 +76,15 @@ namespace QuantumHangar.Utils
             }
         }
 
-        public static void DisplayGridSelection(ulong target, IEnumerable<MyCubeGrid> grids,
+        public static void DisplayGridSelection(ulong target, GridStamp stamp,
             int displayFor = DefaultDisplayFor)
         {
             removeAll(target);
 
             var timer = new PreviewBoxTimer(target, displayFor);
-            var color = new Color(255, 255, 0, 10);
-            foreach (var grid in grids)
-                timer.drawobjectMessage.addOBBLinkedEntity(grid.EntityId, color, MySimpleObjectRasterizer.Wireframe,
-                    1f, 0.005f);
+            var color = new Color(255, 240, 32, 255);
+            timer.drawobjectMessage.addOBB(stamp.Box, stamp.MatrixTranslation, stamp.BoundingBox.Orientation.Forward,
+                stamp.BoundingBox.Orientation.Up, color, MySimpleObjectRasterizer.Wireframe, 1f, 0.02f);
 
             timer.display();
         }

--- a/Quantumhangar/Utils/PreviewBoxTimer.cs
+++ b/Quantumhangar/Utils/PreviewBoxTimer.cs
@@ -82,9 +82,13 @@ namespace QuantumHangar.Utils
             removeAll(target);
 
             var timer = new PreviewBoxTimer(target, displayFor);
-            var color = new Color(255, 240, 32, 255);
+            var color = new Color(255, 255, 96, 255);
             timer.drawobjectMessage.addOBB(stamp.Box, stamp.MatrixTranslation, stamp.BoundingBox.Orientation.Forward,
-                stamp.BoundingBox.Orientation.Up, color, MySimpleObjectRasterizer.Wireframe, 1f, 0.02f);
+                stamp.BoundingBox.Orientation.Up, color, MySimpleObjectRasterizer.Wireframe, 1.2f, 0.01f);
+
+            var drawBox = timer.drawobjectMessage.drawObjects.LastOrDefault();
+            if (drawBox != null)
+                drawBox.wireDivideRatio = 1;
 
             timer.display();
         }

--- a/Quantumhangar/Utils/PreviewBoxTimer.cs
+++ b/Quantumhangar/Utils/PreviewBoxTimer.cs
@@ -52,7 +52,7 @@ namespace QuantumHangar.Utils
         {
             for (int i = list.Count - 1; i >= 0; i--)
             {
-                if (list[i].timeDisplayed > list[i]._displayFor)
+                if (list[i].timeDisplayed >= list[i]._displayFor)
                 {
                     list[i].remove();
                     list.RemoveAt(i);

--- a/Quantumhangar/manifest.xml
+++ b/Quantumhangar/manifest.xml
@@ -3,5 +3,5 @@
 	<Name>Quantum Hangar</Name>
 	<Guid>24fc7724-0740-4a54-8bb3-1191fd3c8db4</Guid>
 	<Repository>Quantum Hangar</Repository>
-	<Version>v3.2.70</Version>
+	<Version>v3.2.71</Version>
 </PluginManifest>


### PR DESCRIPTION
This pull request introduces a two-step confirmation process for saving grids, improves currency handling for save operations, and enhances the handling of projector projections during grid spawning. The main themes are improved user experience and reliability for grid saving, as well as better handling of complex grid features like projectors.

**Hangar Save Confirmation Flow:**

* Added a staged confirmation system for saving grids: the initial `SaveGrid` command now stages the save and requires a follow-up `!hangar confirm` command within 30 seconds to complete the save, preventing accidental saves and ensuring the player is aware of the cost. (`Quantumhangar/Commands/Player/HangarCommands.cs`, `Quantumhangar/Hangar.cs`, `Quantumhangar/HangarChecks/Player/PlayerChecks.cs`, [[1]](diffhunk://#diff-65c3767dd36ce19d282fe2c318d2bd9798c32d8872fd0ed7b2bcd2b01c5e85baR46-R68) [[2]](diffhunk://#diff-65c3767dd36ce19d282fe2c318d2bd9798c32d8872fd0ed7b2bcd2b01c5e85baR262-R284) [[3]](diffhunk://#diff-97f2c468e768bb599240643807f810f5fe41373de295a0066bd896a0973c33d4R34-R47) [[4]](diffhunk://#diff-97f2c468e768bb599240643807f810f5fe41373de295a0066bd896a0973c33d4R124-R137) [[5]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL138-R183) [[6]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL158-L167)
* Introduced a `PendingSaveConfirmation` class and related management methods to track and expire staged saves per player. (`Quantumhangar/Hangar.cs`, [[1]](diffhunk://#diff-65c3767dd36ce19d282fe2c318d2bd9798c32d8872fd0ed7b2bcd2b01c5e85baR262-R284) [[2]](diffhunk://#diff-65c3767dd36ce19d282fe2c318d2bd9798c32d8872fd0ed7b2bcd2b01c5e85baR46-R68)
* Updated currency deduction logic: currency is now only charged on confirmation, and all cost checking is centralized and clarified. (`Quantumhangar/HangarChecks/Player/PlayerChecks.cs`, [[1]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL138-R183) [[2]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL158-L167) [[3]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL176-L188) [[4]](diffhunk://#diff-3df399ebd94fa4fca5cf31a24514174d74dc8fd0732dd602eab851feee3b3d7cL205-R275)

**Projector Projection Handling:**

* Improved grid spawning to correctly save and restore projector projections, ensuring that complex grids with projectors retain their blueprints after spawning. (`Quantumhangar/Utils/ParallelSpawner.cs`, [[1]](diffhunk://#diff-7c585cf84111df6e7ec0d49233efdc5e64ae91f669b7c55148b359c3a803e356R31-R48) [[2]](diffhunk://#diff-7c585cf84111df6e7ec0d49233efdc5e64ae91f669b7c55148b359c3a803e356R135-R142) [[3]](diffhunk://#diff-7c585cf84111df6e7ec0d49233efdc5e64ae91f669b7c55148b359c3a803e356R594-R628)

**Preview Box Improvements:**

* Enhanced the preview box timer to support custom display durations and added a utility method for displaying grid selections during the confirmation window. (`Quantumhangar/Utils/PreviewBoxTimer.cs`, [[1]](diffhunk://#diff-894be60f01e26fb8d639cd2afaba299762d5d8e6f419af2f5b2973fb5d9b4c63L15-R29) [[2]](diffhunk://#diff-894be60f01e26fb8d639cd2afaba299762d5d8e6f419af2f5b2973fb5d9b4c63L49-R55) [[3]](diffhunk://#diff-894be60f01e26fb8d639cd2afaba299762d5d8e6f419af2f5b2973fb5d9b4c63R79-R95)

**Miscellaneous:**

* Updated plugin version to `v3.2.71`. (`Quantumhangar/manifest.xml`, [Quantumhangar/manifest.xmlL6-R6](diffhunk://#diff-20f5f5f0227a04f55bdd40eec6cbf7dd84adb7f31747e1143bb94a6bb6a7a072L6-R6))

These changes collectively make the save process safer and more transparent for players, improve currency handling, and ensure projector blueprints are preserved during grid operations.