### PR TITLE
Recursive projector restore sanitization

### DIFF
--- a/Quantumhangar/Utils/ParallelSpawner.cs
+++ b/Quantumhangar/Utils/ParallelSpawner.cs
@@ -598,12 +598,52 @@ namespace QuantumHangar
         private static List<MyObjectBuilder_CubeGrid> GetProjectedGrids(MyObjectBuilder_Projector projector)
         {
             if (projector.ProjectedGrids != null && projector.ProjectedGrids.Count > 0)
-                return new List<MyObjectBuilder_CubeGrid>(projector.ProjectedGrids);
+                return projector.ProjectedGrids.Where(x => x != null).ToList();
 
             if (projector.ProjectedGrid != null)
                 return new List<MyObjectBuilder_CubeGrid> { projector.ProjectedGrid };
 
             return new List<MyObjectBuilder_CubeGrid>();
+        }
+
+        private static void SanitizeProjectedGridsForRestore(List<MyObjectBuilder_CubeGrid> projectedGrids)
+        {
+            if (projectedGrids == null)
+                return;
+
+            projectedGrids.RemoveAll(x => x == null);
+
+            var visited = new HashSet<MyObjectBuilder_CubeGrid>();
+            foreach (var projectedGrid in projectedGrids)
+                SanitizeProjectedGridForRestore(projectedGrid, visited);
+        }
+
+        private static void SanitizeProjectedGridForRestore(MyObjectBuilder_CubeGrid projectedGrid,
+            HashSet<MyObjectBuilder_CubeGrid> visited)
+        {
+            if (projectedGrid == null || !visited.Add(projectedGrid) || projectedGrid.CubeBlocks == null)
+                return;
+
+            foreach (var cubeBlock in projectedGrid.CubeBlocks)
+            {
+                if (cubeBlock == null)
+                    continue;
+
+                if (cubeBlock.ConstructionStockpile != null)
+                    cubeBlock.ConstructionStockpile.Items = Array.Empty<MyObjectBuilder_StockpileItem>();
+
+                if (!(cubeBlock is MyObjectBuilder_Projector projector))
+                    continue;
+
+                if (projector.ProjectedGrids != null)
+                {
+                    projector.ProjectedGrids.RemoveAll(x => x == null);
+                    foreach (var nestedProjectedGrid in projector.ProjectedGrids)
+                        SanitizeProjectedGridForRestore(nestedProjectedGrid, visited);
+                }
+
+                SanitizeProjectedGridForRestore(projector.ProjectedGrid, visited);
+            }
         }
 
         private void RestoreProjectorProjections()
@@ -627,6 +667,8 @@ namespace QuantumHangar
 
                 try
                 {
+                    SanitizeProjectedGridsForRestore(projectorProjection.ProjectedGrids);
+
                     object arg;
                     var paramType = parameters[0].ParameterType;
                     if (paramType.IsArray && paramType.GetElementType() == typeof(MyObjectBuilder_CubeGrid))

--- a/Quantumhangar/manifest.xml
+++ b/Quantumhangar/manifest.xml
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PluginManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<Name>Quantum Hangar</Name>
 	<Guid>24fc7724-0740-4a54-8bb3-1191fd3c8db4</Guid>
 	<Repository>Quantum Hangar</Repository>
-	<Version>v3.2.71</Version>
+	<Version>v3.2.72</Version>
 </PluginManifest>


### PR DESCRIPTION
This pull request introduces improvements to the handling and restoration of projected grids in the `ParallelSpawner` utility. The main focus is on sanitizing projected grids to remove null entries and clear out construction stockpiles, both for top-level and nested projector grids. This helps prevent errors during restoration and ensures cleaner data structures.

**Enhancements to projected grid sanitization:**

* Added `SanitizeProjectedGridsForRestore` and `SanitizeProjectedGridForRestore` methods to recursively remove null entries from projected grids and clear construction stockpiles in `MyObjectBuilder_CubeGrid` objects. This also handles nested projector grids to ensure all levels are sanitized.
* Updated `RestoreProjectorProjections` to call the new sanitization method before restoring projections, ensuring only valid and clean data is used in the restoration process.

**Bug fix for projected grids retrieval:**

* Modified `GetProjectedGrids` to filter out null grids when returning the list, preventing potential null reference issues.